### PR TITLE
feat: Allow GitHub token to avoid GitHub API rate limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.12
 
 RUN apk --no-cache --update add bash git \
+    jq curl \
     && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM alpine:3.12
 
-RUN apk --no-cache --update add bash git \
-    jq curl \
+RUN apk --no-cache --update add \
+    bash \
+    curl \
+    git \
+    jq \
     && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ There are a number of optional inputs that can be used in the `with:` block.
 
 **version** - the version of tfsec to use, defaults to `latest`
 
-**format*** Default format can be overridden to any of the following - [json,csv,checkstyle,junit,sarif]
+**format** - Default format can be overridden to any of the following - [json,csv,checkstyle,junit,sarif]
 
 **additional_args** - any additional arguments you want to have passed to tfsec
 
 **soft_fail** - set to `true` if you dont want the action to break the build
+
+**github_token** - a GitHub token to be used when calling the GitHub API, which helps in avoiding rate-limiting
 
 ### tfsec_vars
 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,13 @@ jobs:
 
 ```
 
+## Open Source Attribution
+
+- bash: [GPL 3.0 or later](https://www.gnu.org/licenses/gpl-3.0.html)
+- curl: [curl license](https://curl.se/docs/copyright.html)
+- git: [GPL 2.0 or later](https://github.com/git/git/blob/master/COPYING)
+- jq: [MIT](https://github.com/stedolan/jq/blob/master/COPYING) 
+
+## License
+
+[MIT License](https://github.com/nkuik/tfsec-action/blob/master/LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     description: |
       Directory to run the action on, from the repo root.
-      Default is . ( root of the repository)
+      Default is . (root of the repository)
     default: "."
   version:
     required: false
@@ -20,7 +20,7 @@ inputs:
   additional_args:
     required: false
     description: |
-      Space seperated args specified here will be added during tfsec execution.
+      Space separated args specified here will be added during tfsec execution.
       (eg. --force-all-dirs --verbose)
   soft_fail:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,11 @@ inputs:
   soft_fail:
     required: false
     description: If set to `true` the action step won't break the  build
+  github_token:
+    description: |
+      GitHub token used for making authenticated requests to the GitHub API,
+      which helps avoid rate limiting
+    required: false
 outputs:
   tfsec-return-code:
     description: "tfsec command return code"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,44 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -xe
 
-TFSEC_VERSION="latest"
-if [ "$INPUT_VERSION" != "latest" ]; then
-  TFSEC_VERSION="tags/${INPUT_VERSION}"
+if [ -z "${INPUT_GITHUB_TOKEN}" ] ; then
+  echo "Consider setting a GITHUB_TOKEN to prevent GitHub api rate limits." >&2
 fi
 
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec
-install tfsec /usr/local/bin/
+TFSEC_VERSION=""
+if [ "$INPUT_VERSION" != "latest" ] && [ -n "$INPUT_VERSION" ]; then
+  TFSEC_VERSION="tags/${INPUT_VERSION}"
+else
+  TFSEC_VERSION="latest"
+fi
+
+function get_release_assets {
+  repo="$1"
+  version="$2"
+  args=(
+    -sSL
+    --header "Accept: application/vnd.github+json"
+  )
+  [ -n "${INPUT_GITHUB_TOKEN}" ] && args+=(--header "Authorization: Bearer ${INPUT_GITHUB_TOKEN}")
+  curl "${args[@]}" "https://api.github.com/repos/${repo}/releases/${version}" | jq '.assets[] | { name: .name, download_url: .browser_download_url }'
+}
+
+function install_release {
+  repo="$1"
+  version="$2"
+  binary="$3-linux-amd64"
+  checksum="$4"
+  release_assets="$(get_release_assets "${repo}" "${version}")"
+
+  curl -sLo "${binary}" "$(echo "${release_assets}" | jq -r ". | select(.name == \"${binary}\") | .download_url")"
+  curl -sLo "$3-checksums.txt" "$(echo "${release_assets}" | jq -r ". | select(.name | contains(\"$checksum\")) | .download_url")"
+
+  grep "${binary}" "$3-checksums.txt" | sha256sum -c -
+  install "${binary}" "/usr/local/bin/${3}"
+}
+
+install_release aquasecurity/tfsec "${TFSEC_VERSION}" tfsec tfsec_checksums.txt
 
 if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
@@ -24,4 +54,4 @@ fi
 
 FORMAT=${INPUT_FORMAT:-default}
 
-tfsec  --format=${FORMAT} ${SOFT_FAIL} ${TFSEC_ARGS_OPTION} "${INPUT_WORKING_DIRECTORY}" 
+tfsec --format="${FORMAT}" ${SOFT_FAIL} ${TFSEC_ARGS_OPTION} "${INPUT_WORKING_DIRECTORY}"


### PR DESCRIPTION
This should solve the GitHub API rate limiting issue I created: https://github.com/aquasecurity/tfsec-action/issues/8

Heavily inspired (to the point of almost copying) by: https://github.com/aquasecurity/tfsec-pr-commenter-action/pull/82 